### PR TITLE
fix `make docker` on raspberry pi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ clean:
 	rm -f owntracks2db/owntracks2db
 
 docker:
-	docker build  --force-rm  -t db2web:$(TAG)  -f Dockerfile.db2web  .
-	docker build  --force-rm  -t owntracks2db:$(TAG)  -f Dockerfile.owntracks2db  .
+	docker build  --network=host  --force-rm  -t db2web:$(TAG)  -f Dockerfile.db2web  .
+	docker build  --network=host  --force-rm  -t owntracks2db:$(TAG)  -f Dockerfile.owntracks2db  .
 
 install:
 	cp  db2web/db2web  /usr/local/bin


### PR DESCRIPTION
needs `--network=host` option for some reason

Signed-off-by: John D Sheehan <john.d.sheehan@gmail.com>